### PR TITLE
Actualizar requirements.txt incluyendo mysql

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ bcrypt~=4.3.0
 seaborn==0.13.2
 streamlit==1.42.2
 SQLAlchemy~=2.0.40
+mysql-connector-python==9.3.0


### PR DESCRIPTION
Actualmente existe el siguiente inconveniente en el cloud, que es debido a que no se encuentran paquetes necesarios instalados en `requirements.txt`. Ver Figura 1 al final de este mensaje.
Este inconveniente se soluciona agregando el paquete `mysql-connector-python` dentro de `requirements.txt`.
Por otra parte, es importante que nuestro `secrets.toml` de Cloud esté estructurado como aparece en la descripción de https://github.com/espinozajgch/soccer-central-web-app/pull/12 @espinozajgch .

Demo: https://soccer-central-web-app-eb4n34ofydvutztdntaqsn.streamlit.app/

Figura 1. Error que marca Cloud
![image](https://github.com/user-attachments/assets/5fc47c91-180f-435b-8384-40cfa12b89ba)

