### PR TITLE
Fix para mostrar pagina en assessments y filtro de busqueda

### DIFF
--- a/pages/player_assessments.py
+++ b/pages/player_assessments.py
@@ -34,7 +34,7 @@ def show_player_assessments_page():
     st.divider()
 
     st.subheader("Agregar nueva evaluación")
-    coach_id = session.query(Users).filter(Users.role.has(role_name="Coach")).first().user_id  # ⚠️ reemplazar con actual usuario coach si se tiene
+    coach_id = session.query(Users).filter(Users.email == st.session_state.usuario).first().user_id
     category = st.selectbox("Categoría", ["technical", "physical", "mental"])
     item = st.text_input("Ítem evaluado")
     value = st.text_input("Valor")

--- a/pages/player_assessments.py
+++ b/pages/player_assessments.py
@@ -1,9 +1,14 @@
 import streamlit as st
 from sqlalchemy.orm import Session
 from db import SessionLocal
+from utils import login
 from models import PlayerAssessments, Players, Users
 import datetime
 
+def Setup_page():
+    login.generarLogin()
+    logo = "./assets/images/soccer-central.png"
+    st.sidebar.image(logo, width=350)
 
 def show_player_assessments_page():
     st.title("Evaluaciones de Jugadores")
@@ -51,3 +56,9 @@ def show_player_assessments_page():
         st.success("✅ Evaluación guardada correctamente")
         st.rerun()
 
+def main():
+    Setup_page()
+    show_player_assessments_page()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Actualmente no se muestra la página de _assessments_ (evaluaciones) del #26 .
Es necesario realizar una modificación sobre la página correspondiente a fin de poder dar la funcionalidad esperada.
Se agregó este mismo fix al Pull Request actual.

Este Pull Request:
- [x] Añade un fix sobre _assessments_ para que se pueda visualizar la página correctamente. @sisco0 
- [x] Crea un filtro para la búsqueda de jugadores en _assessments_. @Ray1977 @espinozajgch 
- [x] Usa un slider para el valor, escala Likert. @Ray1977 

Evidencia en local:
![image](https://github.com/user-attachments/assets/a32fd444-722b-4036-b076-79924b45d6cc)

