### PR TITLE
Usar joinedload para consultas grandes con join y eliminar funciones no utilizadas

### DIFF
--- a/pages/player_assessments.py
+++ b/pages/player_assessments.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from db import SessionLocal
 from utils import login
 from models import PlayerAssessments, Players, Users
@@ -14,7 +14,7 @@ def show_player_assessments_page():
     session: Session = SessionLocal()
 
     # Cargamos todos los jugadores con su usuario relacionado
-    jugadores = session.query(Players).join(Users).filter(Players.user_id == Users.user_id).all()
+    jugadores = session.query(Players).options(joinedload(Players.user)).join(Users).filter(Players.user_id == Users.user_id).all()
 
     # Extraemos valores únicos para los filtros
     posiciones = sorted({p.primary_position for p in jugadores if p.primary_position})
@@ -38,7 +38,7 @@ def show_player_assessments_page():
         aplicar_filtro = st.form_submit_button("Aplicar filtros")
 
     # Construimos la query dinámica
-    query = session.query(Players).join(Users).filter(Players.user_id == Users.user_id)
+    query = session.query(Players).options(joinedload(Players.user)).join(Users).filter(Players.user_id == Users.user_id)
 
 
     if filtro_nombre:


### PR DESCRIPTION
Por accidente se eliminaron las operaciones de `joinedload` en el commit 2d9180534a5ddb9ac4df4532c1badb47b1403336.
El presente Pull Request arregla este inconveniente, haciendo cherry-pick del commit del Pull Request original https://github.com/espinozajgch/soccer-central-web-app/pull/29.