### PR TITLE
Add Core values to categories in Player Assessment

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -343,7 +343,7 @@ class PlayerAssessments(Base):
     assessment_id: Mapped[int] = mapped_column(Integer, primary_key=True, comment='ID único de la evaluación')
     player_id: Mapped[int] = mapped_column(Integer, nullable=False, comment='Jugador evaluado')
     coach_id: Mapped[int] = mapped_column(Integer, nullable=False, comment='Entrenador que realiza la evaluación')
-    category: Mapped[str] = mapped_column(SqlEnum("Técnico", "Físico", "Mental", "Táctico", "Colectivo", "Valores", name="category_enum"), nullable=False)
+    category: Mapped[str] = mapped_column(SqlEnum("Técnico", "Físico", "Mental", "Táctico", "Colectivo", "Valores", "Core Value 1", "Core Value 2", "Core Value 3", "Core Value 4", "Core Value 5", name="category_enum"), nullable=False)
     core_value_id: Mapped[Optional[int]] = mapped_column(Integer, comment='Valor fundamental asociado')
     program_id: Mapped[Optional[int]] = mapped_column(Integer, comment='Programa relacionado con la evaluación')
     item: Mapped[str] = mapped_column(String(255), nullable=False, comment='Ítem o aspecto evaluado')


### PR DESCRIPTION
`player_assessments` SQL table required to be modified in the `category` column with the intention to provide options for _Core Values_ from 1 to 5.
This request was made by @Ray1977 and it was already applied in the backend as well.
New structure of the DB table is as follows:
```sql
CREATE TABLE `player_assessments` (
	`assessment_id` INT NOT NULL AUTO_INCREMENT COMMENT 'ID único de la evaluación',
	`player_id` INT NOT NULL COMMENT 'Jugador evaluado',
	`coach_id` INT NOT NULL COMMENT 'Entrenador que realiza la evaluación',
	`category` ENUM('Technical Skills','Tactical Understanding','Physical Performance','Match Performance & Consistency','Leadership & Character Development','Core Value 1','Core Value 2','Core Value 3','Core Value 4','Core Value 5') NOT NULL COLLATE 'utf8mb4_0900_ai_ci',
	`core_value_id` INT NULL DEFAULT NULL COMMENT 'Valor fundamental asociado',
	`program_id` INT NULL DEFAULT NULL COMMENT 'Programa relacionado con la evaluación',
	`item` VARCHAR(255) NOT NULL COMMENT 'Ítem o aspecto evaluado' COLLATE 'utf8mb4_0900_ai_ci',
	`value` INT NOT NULL COMMENT 'Valor numérico asignado',
	`notes` TEXT NULL DEFAULT NULL COMMENT 'Observaciones del entrenador' COLLATE 'utf8mb4_0900_ai_ci',
	`created_at` DATETIME NOT NULL COMMENT 'Fecha de creación del registro',
	PRIMARY KEY (`assessment_id`) USING BTREE,
	INDEX `coach_id` (`coach_id`) USING BTREE,
	INDEX `program_id` (`program_id`) USING BTREE,
	INDEX `core_value_id` (`core_value_id`) USING BTREE,
	INDEX `player_id` (`player_id`) USING BTREE,
	CONSTRAINT `player_assessments_ibfk_1` FOREIGN KEY (`player_id`) REFERENCES `players` (`player_id`) ON UPDATE NO ACTION ON DELETE NO ACTION,
	CONSTRAINT `player_assessments_ibfk_2` FOREIGN KEY (`coach_id`) REFERENCES `users` (`user_id`) ON UPDATE NO ACTION ON DELETE NO ACTION,
	CONSTRAINT `player_assessments_ibfk_3` FOREIGN KEY (`core_value_id`) REFERENCES `core_values` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION,
	CONSTRAINT `player_assessments_ibfk_4` FOREIGN KEY (`program_id`) REFERENCES `programs` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION
)
COMMENT='Evaluaciones cualitativas realizadas por los entrenadores a los jugadores'
COLLATE='utf8mb4_0900_ai_ci'
ENGINE=InnoDB
AUTO_INCREMENT=50
;
```

No test is required considering that Rayner's proposal would be in a later Pull Request.